### PR TITLE
Fixed CORS error in latest firefox

### DIFF
--- a/src/manifest_gecko.json
+++ b/src/manifest_gecko.json
@@ -8,7 +8,8 @@
 		"storage",
 		"unlimitedStorage",
 		"alarms",
-		"https://www.google.com/"
+		"https://www.google.com/",
+		"https://*.gstatic.com/"
 	],
 
 	"options_ui": {


### PR DESCRIPTION
I've installed the extension but it's not working, turned out it's caused by the CORS error when fetching the site favicons from `*.gstatic.com`, the host name is redirected from previous google favicon api, just add it to `permissions` to fix it.